### PR TITLE
Factory should retain a reference to protocol for future reference.

### DIFF
--- a/mqtt/client/factory.py
+++ b/mqtt/client/factory.py
@@ -92,7 +92,8 @@ class MQTTFactory(ReconnectingClientFactory):
         self.windowSubscribe[addr] = v
         v = self.windowUnsubscribe.get(addr, dict())
         self.windowUnsubscribe[addr] = v
-        return MQTTProtocol(self, addr)
+	self.protocol = MQTTProtocol(self, addr)
+        return protocol
 
 
     def clientConnectionLost(self, connector, reason):

--- a/mqtt/client/pubsubs.py
+++ b/mqtt/client/pubsubs.py
@@ -151,7 +151,8 @@ class MQTTProtocol(MQTTBaseProtocol):
         self._factor       =  self.DEFAULT_FACTOR
         # additional, per-connection subscriber state
         self._onPublish   = None
-        
+	# a callback for when .connect() is done
+	self._onMqttConnectionMade = None  
       
        
     # -----------------------------
@@ -356,6 +357,8 @@ class MQTTProtocol(MQTTBaseProtocol):
             self._purgeSession()
         else:
             self._syncSession()
+        if self._onMqttConnectionMade:
+            self._onMqttConnectionMade()
 
     # ---------------------------
     # State Machine API callbacks

--- a/mqtt/client/pubsubs.py
+++ b/mqtt/client/pubsubs.py
@@ -161,9 +161,9 @@ class MQTTProtocol(MQTTBaseProtocol):
   
     def setBandwith(self, bandwith, factor=2):
         if bandwith <= 0:
-            raise VauleError("Bandwith should be a positive number")
+            raise ValueError("Bandwith should be a positive number")
         if factor <= 0:
-            raise VauleError("Bandwith should be a positive number")
+            raise ValueError("Bandwith should be a positive number")
         self._bandwith = bandwith
         self._factor   = factor
 
@@ -592,7 +592,7 @@ class MQTTProtocol(MQTTBaseProtocol):
         '''
         Handle the absence of PUBCOMP 
         '''
-        log.error("{packet:7} (id={request.msgId:04x} qos={request.qos}) {timeout}, _retryPublish", packet="PUBCOMP", request=request, timeout="timeout")
+        log.error("{packet:7} (id={request.msgId:04x}) {timeout}, _retryPublish", packet="PUBCOMP", timeout="timeout")
         self._retryRelease(reply, dup=True)
 
     # --------------------------------------------------------------------------

--- a/mqtt/client/pubsubs.py
+++ b/mqtt/client/pubsubs.py
@@ -117,8 +117,8 @@ class ConnectedState(BaseConnectedState):
         self.protocol.handlePUBREC(response)
 
     # QoS=2 packets forwarded to subscriber
-    def handlePUBREL(self, dup, response):
-        self.protocol.handlePUBREL(dup, response)
+    def handlePUBREL(self, response):
+        self.protocol.handlePUBREL(response)
 
     # QoS=2 packets forwarded to publisher
     def handlePUBCOMP(self, response):


### PR DESCRIPTION
Inside the factory, their should be a reference to the protocol that was built. This can be used by the factory or the service that created the factory to reference the protocol easier.